### PR TITLE
allow the net_kernel node host to be set to a hostname or the ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,10 +253,16 @@ disabled.
 #### `:node_name`
 
 This is the node name for Erlang distribution. If specified, `epmd` will be
-started and the node will be configured as `:name@ip_address`. You'll be able to
+started and the node will be configured as `:name@host`. You'll be able to
 see the node's name at the IEx prompt and it's possible to determine
 programmatically by resolving `nerves.local` on a host if you need to write
 something that automatically connects.
+
+#### `:node_host`
+
+Defaults to `:ip` which means that it will use the ip of the interface specified
+in `:ifname`. You can also set this to a hostname such as the one configured in
+`:mdns_domain`.
 
 Currently only long names are supported (i.e., no snames).
 

--- a/lib/nerves_init_gadget/network_manager.ex
+++ b/lib/nerves_init_gadget/network_manager.ex
@@ -40,7 +40,8 @@ defmodule Nerves.InitGadget.NetworkManager do
   defp handle_ip_update(state, new_ip) do
     Logger.debug("IP address for #{state.ifname} changed to #{new_ip}")
     update_mdns(new_ip, state.opts.mdns_domain)
-    update_net_kernel(new_ip, state.opts.node_name)
+    host = if state.opts.node_host == :ip, do: new_ip, else: state.opts.node_host
+    update_net_kernel(host, state.opts.node_name)
     {:noreply, %{state | ip: new_ip}}
   end
 

--- a/lib/nerves_init_gadget/options.ex
+++ b/lib/nerves_init_gadget/options.ex
@@ -4,6 +4,7 @@ defmodule Nerves.InitGadget.Options do
   defstruct ifname: "usb0",
             address_method: :linklocal,
             mdns_domain: "nerves.local",
-            node_name: nil
+            node_name: nil,
+            node_host: :ip
 
 end


### PR DESCRIPTION
Adds a key to the possible config that lets you set the host part of the node name to a hostname instead of just an ip address. 