### PR TITLE
give the interface time to settle before rejoining mdns

### DIFF
--- a/lib/nerves_init_gadget/network_manager.ex
+++ b/lib/nerves_init_gadget/network_manager.ex
@@ -58,6 +58,11 @@ defmodule Nerves.InitGadget.NetworkManager do
   defp update_mdns(ip, _mdns_domain) do
     ip_tuple = to_ip_tuple(ip)
     Mdns.Server.stop()
+    # Give the interface time to settle
+    # This needs to be revisited.
+    # The issue is that without a delay, the multicast memberships are not
+    # properly established with linux and silently fail.
+    :timer.sleep(100)
     Mdns.Server.start(interface: ip_tuple)
     Mdns.Server.set_ip(ip_tuple)
   end


### PR DESCRIPTION
While using `nerves_init_gadget` with `wlan0` I have found that the multicast group memberships were not being established once the ip changes.

What I was experiencing
Once the device was fully booted and has connected to the network and the IP address is up mdns would not properly restart. I would no longer see mdns logger outpus in the console of the device, and I was no longer able to send queries to it from other devices on the network.
Here is the output of ``
```
Idx     Device    : Count Querier       Group    Users Timer    Reporter
1       lo        :     1      V3
                                010000E0     1 0:00000000               0
4       wlan0     :     1      V3
                                010000E0     1 0:00000000               0
```

What should happen
After adding in a sleep of 100 ms I was able to get consistent registration results. Here is the output of `` after
```
cmd("cat /proc/net/igmp")
Idx     Device    : Count Querier       Group    Users Timer    Reporter
1       lo        :     1      V3
                                010000E0     1 0:00000000               0
4       wlan0     :     3      V3
                                FB0000E0     1 0:00000000               0
                                010000E0     1 0:00000000               0
```

There is a deeper problem that is at play here and we need to revisit this to find a better solution. We need to come up with a way that we can monitor multicast group registrations