### PR TITLE
More explicit instructions on handling USB

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,10 @@ mix firmware.burn
 
 ## Using
 
-Give your device a few seconds to boot and initialize the virtual Ethernet
-interface going through the USB cable. On your computer, run `ping` to see that
+Connect your RPi0 over the USB port with your computer (use the port labeled
+"USB", not the one labeled "PWR").  Give your device a few seconds to boot and
+initialize the virtual Ethernet interface going through the USB cable. On your
+computer, run `ping` to see that
 it's working:
 
 ```sh


### PR DESCRIPTION
It took me a while to figure out I needed to connect by computer via the USB port, not the PWR port. Although completely obvious (afterwards), it took me a while to figure out.

Hence a small readme update, to make it even more explicit what one has to do.