### PR TITLE
Add ssh console.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ code. Here's a summary of what you get:
 * Over-the-air firmware updates using `nerves_firmware_ssh`
 * Easy setup of Erlang distribution to support remsh, Observer and other debug
   and tracing tools
+* A ssh IEx console.
 * IEx helpers for a happier commandline experience
 * Logging via [ring_logger](https://github.com/nerves-project/ring_logger)
 * [shoehorn](https://github.com/nerves-project/shoehorn)-aware instructions to
@@ -308,6 +309,20 @@ The default is `:mdns_domain` so that the following remsh invocation works:
 
 ```bash
 iex --name me@0.0.0.0 --cookie acookie --remsh node_name@nerves.local
+```
+
+### `:ssh_console_port`
+
+If specified (non-nil), Start an IEx console on a ssh port. This console will
+use the same keys configured with `:nerves_firmware_ssh`.
+You can connect by doing the following:
+```bash
+ssh nerves.local
+```
+
+To exit you will have to do:
+```elixir
+Nerves.InitGadget.SSHConsole.shell_exit()
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ code. Here's a summary of what you get:
 * Over-the-air firmware updates using `nerves_firmware_ssh`
 * Easy setup of Erlang distribution to support remsh, Observer and other debug
   and tracing tools
-* A ssh IEx console.
+* Access to the IEx console via ssh
 * IEx helpers for a happier commandline experience
 * Logging via [ring_logger](https://github.com/nerves-project/ring_logger)
 * [shoehorn](https://github.com/nerves-project/shoehorn)-aware instructions to
@@ -313,9 +313,10 @@ iex --name me@0.0.0.0 --cookie acookie --remsh node_name@nerves.local
 
 ### `:ssh_console_port`
 
-If specified (non-nil), Start an IEx console on a ssh port. This console will
+If specified (non-nil), start an IEx console on a ssh port. This console will
 use the same keys configured with `:nerves_firmware_ssh`.
-You can connect by doing the following:
+You can connect by setting `ssh_console_port: 22` and then run:
+
 ```bash
 ssh nerves.local
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ code. Here's a summary of what you get:
 * Over-the-air firmware updates using `nerves_firmware_ssh`
 * Easy setup of Erlang distribution to support remsh, Observer and other debug
   and tracing tools
-* Access to the IEx console via ssh
+* Access to the IEx console via `ssh`
 * IEx helpers for a happier commandline experience
 * Logging via [ring_logger](https://github.com/nerves-project/ring_logger)
 * [shoehorn](https://github.com/nerves-project/shoehorn)-aware instructions to
@@ -67,13 +67,14 @@ haven't used `shoehorn` before, it separates the application initialization
 into phases to isolate failures. This lets us ensure that `nerves_init_gadget`
 runs even if we messed up something in our application code. It's useful during
 development so that you can send firmware updates to devices with broken
-software.
+software. Take a look at your `config/config.exs` and edit the `:shoehorn`
+config to look something like this:
 
 ```elixir
 # Boot Shoehorn first and have it start our app.
 config :shoehorn,
   init: [:nerves_runtime, :nerves_init_gadget],
-  app: :mygadget
+  app: Mix.Project.config()[:app]
 ```
 
 Next, set up the ssh authorized keys for pushing firmware updates to the device.
@@ -88,6 +89,12 @@ config :nerves_firmware_ssh,
     File.read!(Path.join(System.user_home!, ".ssh/id_rsa.pub"))
   ]
 ```
+
+By itself, this does not allow you to log into your device using `ssh`. This is
+only for sending firmware updates to the device. (The `ssh` protocol is really
+cool and lets you do more than just connect to shells.) If you'd like to connect
+to the IEx prompt, see the [:ssh_console_port](#ssh_console_port) configuration
+option.
 
 The last change to the `config.exs` is to replace the default Elixir logger with
 [ring_logger](https://github.com/nerves-project/ring_logger). Eventually you may
@@ -313,17 +320,20 @@ iex --name me@0.0.0.0 --cookie acookie --remsh node_name@nerves.local
 
 ### `:ssh_console_port`
 
-If specified (non-nil), start an IEx console on a ssh port. This console will
-use the same keys configured with `:nerves_firmware_ssh`.
-You can connect by setting `ssh_console_port: 22` and then run:
+If specified (non-nil), `nerves_init_gadget` will start an IEx console on the
+specified port. This console will use the same ssh public keys as those
+configured for `:nerves_firmware_ssh`. For example, if you set
+`ssh_console_port: 22`, rebuild and update the firmware. Usernames are ignored,
+so you can ssh to the device just by running:
 
 ```bash
 ssh nerves.local
 ```
 
-By default, Nerves cathes the `CTRL-C` signal. This means you will not be able to
-exit an SSH session using that. Instead you should use `~.`.
-See the [ssh man page](https://linux.die.net/man/1/ssh) for more details.
+To exit the SSH session, type `~.`. This is an `ssh` escape sequence (See the
+[ssh man page](https://linux.die.net/man/1/ssh) for other escape sequences).
+Typing `Ctrl+D` or `logoff` at the IEx prompt to exit the session aren't
+implemented.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -321,10 +321,9 @@ You can connect by setting `ssh_console_port: 22` and then run:
 ssh nerves.local
 ```
 
-To exit you will have to do:
-```elixir
-Nerves.InitGadget.SSHConsole.shell_exit()
-```
+By default, Nerves cathes the `CTRL-C` signal. This means you will not be able to
+exit an SSH session using that. Instead you should use `~.`.
+See the [ssh man page](https://linux.die.net/man/1/ssh) for more details.
 
 ## Troubleshooting
 

--- a/lib/nerves_init_gadget/application.ex
+++ b/lib/nerves_init_gadget/application.ex
@@ -11,7 +11,8 @@ defmodule Nerves.InitGadget.Application do
 
     # Define workers and child supervisors to be supervised
     children = [
-      worker(Nerves.InitGadget.NetworkManager, [merged_opts])
+      worker(Nerves.InitGadget.NetworkManager, [merged_opts]),
+      worker(Nerves.InitGadget.SSHConsole, [merged_opts])
     ]
 
     opts = [strategy: :one_for_one, name: Nerves.InitGadget.Supervisor]

--- a/lib/nerves_init_gadget/options.ex
+++ b/lib/nerves_init_gadget/options.ex
@@ -5,5 +5,7 @@ defmodule Nerves.InitGadget.Options do
             address_method: :linklocal,
             mdns_domain: "nerves.local",
             node_name: nil,
-            node_host: :mdns_domain
+            node_host: :mdns_domain,
+            ssh_console: false,
+            ssh_console_port: 22
 end

--- a/lib/nerves_init_gadget/options.ex
+++ b/lib/nerves_init_gadget/options.ex
@@ -6,5 +6,5 @@ defmodule Nerves.InitGadget.Options do
             mdns_domain: "nerves.local",
             node_name: nil,
             node_host: :mdns_domain,
-            ssh_console_port: 22
+            ssh_console_port: nil
 end

--- a/lib/nerves_init_gadget/options.ex
+++ b/lib/nerves_init_gadget/options.ex
@@ -6,6 +6,5 @@ defmodule Nerves.InitGadget.Options do
             mdns_domain: "nerves.local",
             node_name: nil,
             node_host: :mdns_domain,
-            ssh_console: false,
             ssh_console_port: 22
 end

--- a/lib/nerves_init_gadget/ssh_console.ex
+++ b/lib/nerves_init_gadget/ssh_console.ex
@@ -21,9 +21,8 @@ defmodule Nerves.InitGadget.SSHConsole do
   end
 
   defp start_ssh(%{ssh_console_port: port}) do
-    # here we share the keys with `nerves_firmware_ssh`
-    # This allows for the end user to only have to configure ssh keys
-    # in one config.exs entry.
+    # Reuse keys from `nerves_firmware_ssh` so that the user only needs one
+    # config.exs entry.
     authorized_keys =
       Application.get_env(:nerves_firmware_ssh, :authorized_keys, [])
       |> Enum.join("\n")
@@ -32,8 +31,8 @@ defmodule Nerves.InitGadget.SSHConsole do
 
     cb_opts = [authorized_keys: decoded_authorized_keys]
 
-    # here we also share system_dir to allow for auth to work with
-    # the shared keys.
+    # Reuse the system_dir as well to allow for auth to work with the shared
+    # keys.
     {:ok, ssh} =
       :ssh.daemon(port, [
         {:id_string, :random},
@@ -41,6 +40,7 @@ defmodule Nerves.InitGadget.SSHConsole do
         {:system_dir, Nerves.Firmware.SSH.Application.system_dir()},
         {:shell, {Elixir.IEx, :start, []}}
       ])
+
     ssh
   end
 end

--- a/lib/nerves_init_gadget/ssh_console.ex
+++ b/lib/nerves_init_gadget/ssh_console.ex
@@ -1,0 +1,58 @@
+defmodule Nerves.InitGadget.SSHConsole do
+  @moduledoc """
+  SSH IEx console.
+  """
+  use GenServer
+
+  @doc """
+  Since ctrl-c is intercepted in default Nerves config,
+  We need to be able to exit the shell somehow.
+  """
+  def shell_exit, do: GenServer.call(__MODULE__, :ssh_exit)
+
+  @doc false
+  def start_link(%{ssh_console_port: nil}), do: :ignore
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, [opts], name: __MODULE__)
+  end
+
+  def init([opts]) do
+    ssh = start_ssh(opts)
+    {:ok, %{ssh: ssh, opts: opts}}
+  end
+
+  def terminate(_, %{ssh: ssh}) do
+    :ssh.stop_daemon(ssh)
+  end
+
+  def handle_call(:ssh_exit, from, %{ssh: ssh} = state) do
+    # Reply to avoid crashing the call.
+    GenServer.reply(from, :ok)
+    :ok = :ssh.stop_daemon(ssh)
+    # Sleep here so when we restart, the port is open.
+    Process.sleep(5000)
+    new_ssh = start_ssh(state.opts)
+    {:noreply, :ok, %{state | ssh: new_ssh}}
+  end
+
+  defp start_ssh(%{ssh_console_port: port}) do
+    authorized_keys =
+      Application.get_env(:nerves_firmware_ssh, :authorized_keys, [])
+      |> Enum.join("\n")
+
+    decoded_authorized_keys = :public_key.ssh_decode(authorized_keys, :auth_keys)
+
+    cb_opts = [authorized_keys: decoded_authorized_keys]
+
+    {:ok, ssh} =
+      :ssh.daemon(port, [
+        {:id_string, :random},
+        {:key_cb, {Nerves.Firmware.SSH.Keys, cb_opts}},
+        {:system_dir, Nerves.Firmware.SSH.Application.system_dir()},
+        {:shell, {Elixir.IEx, :start, []}}
+      ])
+
+    ssh
+  end
+end

--- a/lib/nerves_init_gadget/ssh_console.ex
+++ b/lib/nerves_init_gadget/ssh_console.ex
@@ -37,6 +37,9 @@ defmodule Nerves.InitGadget.SSHConsole do
   end
 
   defp start_ssh(%{ssh_console_port: port}) do
+    # here we share the keys with `nerves_firmware_ssh`
+    # This allows for the end user to only have to configure ssh keys
+    # in one config.exs entry.
     authorized_keys =
       Application.get_env(:nerves_firmware_ssh, :authorized_keys, [])
       |> Enum.join("\n")
@@ -45,6 +48,8 @@ defmodule Nerves.InitGadget.SSHConsole do
 
     cb_opts = [authorized_keys: decoded_authorized_keys]
 
+    # here we also share system_dir to allow for auth to work with
+    # the shared keys.
     {:ok, ssh} =
       :ssh.daemon(port, [
         {:id_string, :random},

--- a/lib/nerves_init_gadget/ssh_console.ex
+++ b/lib/nerves_init_gadget/ssh_console.ex
@@ -4,12 +4,6 @@ defmodule Nerves.InitGadget.SSHConsole do
   """
   use GenServer
 
-  @doc """
-  Since ctrl-c is intercepted in default Nerves config,
-  We need to be able to exit the shell somehow.
-  """
-  def shell_exit, do: GenServer.call(__MODULE__, :ssh_exit)
-
   @doc false
   def start_link(%{ssh_console_port: nil}), do: :ignore
 
@@ -24,16 +18,6 @@ defmodule Nerves.InitGadget.SSHConsole do
 
   def terminate(_, %{ssh: ssh}) do
     :ssh.stop_daemon(ssh)
-  end
-
-  def handle_call(:ssh_exit, from, %{ssh: ssh} = state) do
-    # Reply to avoid crashing the call.
-    GenServer.reply(from, :ok)
-    :ok = :ssh.stop_daemon(ssh)
-    # Sleep here so when we restart, the port is open.
-    Process.sleep(5000)
-    new_ssh = start_ssh(state.opts)
-    {:noreply, :ok, %{state | ssh: new_ssh}}
   end
 
   defp start_ssh(%{ssh_console_port: port}) do
@@ -57,7 +41,6 @@ defmodule Nerves.InitGadget.SSHConsole do
         {:system_dir, Nerves.Firmware.SSH.Application.system_dir()},
         {:shell, {Elixir.IEx, :start, []}}
       ])
-
     ssh
   end
 end


### PR DESCRIPTION
I don't really know about this. I found myself needing it, so i thought id add it here, but it doesn't really seem to fit in. Maybe its better in `nerves_firmware_ssh`? it doesn't seem really right there either. Feel free to shoot this down.