### PR TITLE
Use usb_gadget to configure gadget devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## vNEXT
+
+* New features
+  * Support for configuration of usb gadget devices using the
+    [`usb_gadget`](https://github.com/nerves-project/usb_gadget) library (when
+    using a compatible Nerves system).
+
 ## v0.5.2
 
 * Enhancements

--- a/README.md
+++ b/README.md
@@ -194,6 +194,29 @@ mix firmware
 mix firmware.burn
 ```
 
+## USB Gadget Devices
+
+By default, `nerves_init_gadget` attempts to use the [`usb_gaget`] library to
+configure the following devices:
+
+1. RNDIS Ethernet interface (`usb0`)
+2. ECM Ethernet interface (`usb1`)
+3. ACM Serial interface (`ttyGS0`)
+
+The reason that there are two Ethernet devices is that the first device
+(`usb0`) uses an RNDIS driver, which interoperates with Windows-based hosts.
+The second device (`usb1`) uses an ECM driver, which interoperates with Linux-
+and OSX-based hosts. `nerves_init_gadget` also configures Ethernet bonding
+between these two devices, allowing you to treat them as a single `bond0`
+interface that will automatically use the appropriate underlying device to
+connect to the host.
+
+Using the [`usb_gadget`] library, you can also configure a variety of other USB
+gadget devices, or customize the devices configured by default in
+`nerves_init_gadget`.
+
+[`usb_gadget`]: https://github.com/nerves-project/usb_gadget
+
 ## Using
 
 Connect your device over the USB port with your computer (if using a RPi0, it is

--- a/lib/nerves_init_gadget.ex
+++ b/lib/nerves_init_gadget.ex
@@ -1,8 +1,9 @@
 defmodule Nerves.InitGadget do
   @moduledoc """
-  `nerves_init_gadget` adds a basic level of setup for Nerves devices with USB gadget mode
-  interfaces like the Raspberry Pi Zero. Here are some features:
+  `nerves_init_gadget` adds a basic level of setup for Nerves devices with USB
+  gadget mode interfaces like the Raspberry Pi Zero. Here are some features:
 
+  * Initialize USB gadget devices using configfs
   * Automatically sets up link-local networking on the USB interface. No DHCP or
     static IP setup is needed on the host laptop
   * Sets up mDNS to respond to lookups for `nerves.local`

--- a/lib/nerves_init_gadget/application.ex
+++ b/lib/nerves_init_gadget/application.ex
@@ -8,6 +8,7 @@ defmodule Nerves.InitGadget.Application do
     opts = InitGadget.Options.get()
 
     children = [
+      {InitGadget.GadgetDevices, opts},
       {InitGadget.NetworkManager, opts},
       {InitGadget.SSHConsole, opts}
     ]

--- a/lib/nerves_init_gadget/gadget_devices.ex
+++ b/lib/nerves_init_gadget/gadget_devices.ex
@@ -1,0 +1,57 @@
+defmodule Nerves.InitGadget.GadgetDevices do
+  @moduledoc """
+  Set up the gadget devices with usb_gadget
+  """
+  use GenServer, restart: :temporary
+
+  require Logger
+
+  @doc false
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def init(_opts) do
+    # Only set up gadget devices if USB gadget configfs is available so that
+    # nerves_init_gadget works on targets that don't have USB OTG ports or
+    # for older systems that have the gadget devices compiled into the kernel.
+    case USBGadget.Builtin.create_rndis_ecm_acm("g") do
+      :ok ->
+        # Make sure we clear out any existing gadget configuration.
+        :os.cmd('rmmod g_cdc')
+        USBGadget.disable_device("g")
+
+        USBGadget.enable_device("g")
+        setup_bond0()
+        {:ok, :ok}
+
+      error ->
+        Logger.warn("Error setting up USB gadgets: #{inspect(error)}")
+        {:ok, error}
+    end
+  end
+
+  def handle_call(:status, _from, state) do
+    {:reply, state, state}
+  end
+
+  def status do
+    GenServer.call(__MODULE__, :status)
+  end
+
+  defp setup_bond0 do
+    # Set up the bond0 interface across usb0 and usb1.
+    # In the rndis_ecm_acm pre-defined device being used here, usb0 is the
+    # RNDIS (Windows-compatible) device and usb1 is the ECM
+    # (non-Windows-compatible) device.
+    # Since Linux supports both with ECM being more reliable, we set usb1 (ECM)
+    # as the primary, meaning that it will be used if both are available.
+    :os.cmd('ip link set bond0 down')
+    File.write("/sys/class/net/bond0/bonding/mode", "active-backup")
+    File.write("/sys/class/net/bond0/bonding/miimon", "100")
+    File.write("/sys/class/net/bond0/bonding/slaves", "+usb0")
+    File.write("/sys/class/net/bond0/bonding/slaves", "+usb1")
+    File.write("/sys/class/net/bond0/bonding/primary", "usb1")
+    :os.cmd('ip link set bond0 up')
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,8 @@ defmodule Nerves.InitGadget.MixProject do
       {:mdns, "~> 1.0"},
       {:ring_logger, "~> 0.4"},
       {:one_dhcpd, "~> 0.1"},
-      {:ex_doc, "~> 0.19", only: [:dev, :test], runtime: false}
+      {:ex_doc, "~> 0.19", only: [:dev, :test], runtime: false},
+      {:usb_gadget, github: "nerves-project/usb_gadget", ref: "master"},
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -16,4 +16,5 @@
   "ring_logger": {:hex, :ring_logger, "0.5.0", "dcf9455914c1969b2d55cacb7d37fc9e4ac02d65b1c3de8135c531497f8aed51", [:mix], [], "hexpm"},
   "socket": {:hex, :socket, "0.3.13", "98a2ab20ce17f95fb512c5cadddba32b57273e0d2dba2d2e5f976c5969d0c632", [:mix], [], "hexpm"},
   "system_registry": {:hex, :system_registry, "0.8.0", "09240347628b001433d18279a2759ef7237ba7361239890d8c599cca9a2fbbc2", [:mix], [], "hexpm"},
+  "usb_gadget": {:git, "https://github.com/nerves-project/usb_gadget.git", "610fff11d74e1e87a560a15f0487de2a99290d13", [ref: "master"]},
 }


### PR DESCRIPTION
This still needs the docs updated and other polishing, but I wanted to get it out there so people can give feedback and try it on their machines.

One thing I noticed is that Windows 10 is kind of annoying about how it does link-local addressing with IPv6 vs. IPv4, which I think is making the mDNS lookup fail even though I can ping the device by checking on the serial console to figure out its IP address.

Related to (but no longer depends on): https://github.com/nerves-project/nerves_system_rpi0/pull/62
Resolves #28