### PR TITLE
Clean up application config

### DIFF
--- a/lib/nerves_init_gadget/application.ex
+++ b/lib/nerves_init_gadget/application.ex
@@ -2,17 +2,17 @@ defmodule Nerves.InitGadget.Application do
   @moduledoc false
 
   use Application
+  alias Nerves.InitGadget
 
   def start(_type, _args) do
-    config_opts = Map.new(Application.get_all_env(:nerves_init_gadget))
-    merged_opts = Map.merge(%Nerves.InitGadget.Options{}, config_opts)
+    opts = InitGadget.Options.get()
 
     children = [
-      {Nerves.InitGadget.NetworkManager, merged_opts},
-      {Nerves.InitGadget.SSHConsole, merged_opts}
+      {InitGadget.NetworkManager, opts},
+      {InitGadget.SSHConsole, opts}
     ]
 
-    opts = [strategy: :one_for_one, name: Nerves.InitGadget.Supervisor]
+    opts = [strategy: :one_for_one, name: InitGadget.Supervisor]
     Supervisor.start_link(children, opts)
   end
 end

--- a/lib/nerves_init_gadget/options.ex
+++ b/lib/nerves_init_gadget/options.ex
@@ -1,10 +1,23 @@
 defmodule Nerves.InitGadget.Options do
   @moduledoc false
 
+  alias Nerves.InitGadget.Options
+
   defstruct ifname: "usb0",
             address_method: :linklocal,
             mdns_domain: "nerves.local",
             node_name: nil,
             node_host: :mdns_domain,
             ssh_console_port: 22
+
+  def get() do
+    :nerves_init_gadget
+    |> Application.get_all_env()
+    |> Enum.into(%{})
+    |> merge_defaults()
+  end
+
+  defp merge_defaults(settings) do
+    Map.merge(%Options{}, settings)
+  end
 end


### PR DESCRIPTION
This centralizes the steps to load configuration from Application config, simplifying the Application supervisor and making it possible to re-load calculate the merged options based on different defaults, which is needed for #32.