### PR TITLE
Switch to rest_for_one on application supervisor

### DIFF
--- a/lib/nerves_init_gadget/application.ex
+++ b/lib/nerves_init_gadget/application.ex
@@ -15,7 +15,7 @@ defmodule Nerves.InitGadget.Application do
       worker(Nerves.InitGadget.SSHConsole, [merged_opts])
     ]
 
-    opts = [strategy: :one_for_one, name: Nerves.InitGadget.Supervisor]
+    opts = [strategy: :rest_for_one, name: Nerves.InitGadget.Supervisor]
     Supervisor.start_link(children, opts)
   end
 end


### PR DESCRIPTION
Because the `SSHConsole` depends on the network being properly set up, if `NetworkManager` were to get into an inconsistent state, crash, and restart, we'd also want `SSHConsole` to restart.

I don't feel strongly about this change because in reality, the underlying OS is maintaining some state outside of these GenServers and they communicate via SystemRegistry, so it would likely be fine to leave them in `one_for_one` mode.