### PR TITLE
Allow the cookie to be overridden in the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,8 @@ config :nerves_init_gadget,
   address_method: :dhcpd,
   mdns_domain: "nerves.local",
   node_name: nil,
-  node_host: :mdns_domain
+  node_host: :mdns_domain,
+  cookie: :host
 ```
 
 The above are the defaults and should work for most users. The following
@@ -329,6 +330,14 @@ ssh nerves.local
 To exit the SSH session, type `~.`. This is an `ssh` escape sequence (See the
 [ssh man page](https://linux.die.net/man/1/ssh) for other escape sequences).
 Typing `Ctrl+D` or `logoff` at the IEx prompt to exit the session won't work.
+
+### `:cookie`
+
+The cookie can be set by passing a string value. The cookie can be set to the
+cookie from the host machine by specifying `:host`.
+
+Default is `nil` which uses the cookie from the `vm.args` or a cookie file
+on the target.
 
 ## Troubleshooting
 

--- a/lib/nerves_init_gadget/network_manager.ex
+++ b/lib/nerves_init_gadget/network_manager.ex
@@ -187,6 +187,11 @@ defmodule Nerves.InitGadget.NetworkManager do
 
       case :net_kernel.start([new_name]) do
         {:ok, _} ->
+          if cookie = opts.cookie do
+            to_cookie(cookie, opts)
+            |> Node.set_cookie()
+          end
+
           Logger.debug("Restarted Erlang distribution as node #{inspect(new_name)}")
 
         {:error, reason} ->
@@ -239,4 +244,22 @@ defmodule Nerves.InitGadget.NetworkManager do
   defp to_node_name(nil, _host), do: nil
   defp to_node_name(_name, nil), do: nil
   defp to_node_name(name, host), do: :"#{name}@#{host}"
+
+  defp to_cookie(:host, opts) do
+    opts.host_cookie
+    |> to_cookie(opts)
+  end
+
+  defp to_cookie(cookie, _opts) when is_binary(cookie) do
+    String.to_atom(cookie)
+  end
+
+  defp to_cookie(cookie, _opts) when is_atom(cookie) do
+    cookie
+  end
+
+  defp to_cookie(cookie, _opts) do
+    Logger.warn("Invalid cookie #{inspect(cookie)}")
+    nil
+  end
 end

--- a/lib/nerves_init_gadget/options.ex
+++ b/lib/nerves_init_gadget/options.ex
@@ -3,12 +3,22 @@ defmodule Nerves.InitGadget.Options do
 
   alias Nerves.InitGadget.Options
 
+  host_cookie_path = Path.join(System.user_home(), ".erlang.cookie")
+
+  host_cookie =
+    case File.read(host_cookie_path) do
+      {:ok, cookie} -> cookie
+      _ -> nil
+    end
+
   defstruct ifname: "usb0",
             address_method: :dhcpd,
             mdns_domain: "nerves.local",
             node_name: nil,
             node_host: :mdns_domain,
-            ssh_console_port: 22
+            ssh_console_port: 22,
+            host_cookie: host_cookie,
+            cookie: nil
 
   def get() do
     :nerves_init_gadget


### PR DESCRIPTION
This PR adds the ability to set the cookie through the config for `nerves_init_gadget`. It also supports the option `:host` to set the target cookie to that of the machine that `nerves_init_gadget` was compiled on. This is primarily interesting for `dev` and `test` environments.