### PR TITLE
Don't override ipv4_address_method.

### DIFF
--- a/lib/nerves_init_gadget/network_manager.ex
+++ b/lib/nerves_init_gadget/network_manager.ex
@@ -92,7 +92,7 @@ defmodule Nerves.InitGadget.NetworkManager do
       :nerves_network
       |> Application.get_env(:default, [])
       |> Keyword.get(to_atom(opts.ifname), [])
-      |> Keyword.put(:ipv4_address_method, opts.address_method)
+      |> Keyword.put_new(:ipv4_address_method, opts.address_method)
 
     Nerves.Network.setup(opts.ifname, network_opts)
     state


### PR DESCRIPTION
Why:

* In some cases it would be nice to leave `:address_method` unassigned
  and configure `:ipv4_address_method` in the nerves_network section.

This change addresses the need by:

* Replace `Keyword.put\3` with `Keyword.put_new\3` which only adds the
  entry if the key doesn't exist.