### PR TITLE
Register names for the autogenerated dhcp addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,8 +273,10 @@ specify the following:
 * `:dhcp` - send a DHCP discovery request on the network to get assigned an IP
   address
 * `:dhcpd` - set an automatically calculated IP address and start a DHCP server
-  to assign an address to the other side of the link. See
-  [OneDHCPD](https://github.com/fhunleth/one_dhcpd)
+  to assign an address to the other side of the link. Names are added to
+  Erlang's DNS so that you can refer to the computer on the other side of the link
+  as `peer.usb0.lan`. Substitute `usb0` for the interface if yours is different.
+  See [OneDHCPD](https://github.com/fhunleth/one_dhcpd).
 
 ### `:mdns_domain`
 


### PR DESCRIPTION
This is for the `dhcpd` address method used for Ethernet connections
that only have two computers on the LAN. The most common use of this is
when connecting a device to a laptop via a virtual Ethernet interface on
a USB cable. A DHCP server is run on the device that assigns the laptop
an address. Since the assigned address is computed, programs can't
hardcode one in to refer to the laptop. This change adds `peer.usb0.lan`
and `local.usb0.lan` to the Erlang resolver's host table where `usb0` is
the Ethernet interface that's being used.

You can query the addresses using `:inet.gethostbyname/1` or dump the
host table using `:inet.get_rc/0`.