### PR TITLE
Make mDNS discovery works for ssh and sftp

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ You may customize `nerves_init_gadget` using your `config.exs`:
 config :nerves_init_gadget,
   ifname: "usb0",
   address_method: :dhcpd,
+  mdns_name: "Nerves Gadget",
   mdns_domain: "nerves.local",
   node_name: nil,
   node_host: :mdns_domain
@@ -279,6 +280,12 @@ specify the following:
   Erlang's DNS so that you can refer to the computer on the other side of the link
   as `peer.usb0.lan`. Substitute `usb0` for the interface if yours is different.
   See [OneDHCPD](https://github.com/fhunleth/one_dhcpd).
+
+### `:mdns_name`
+
+This is the device name for mDNS discovery service. It defaults to `Nerves Gadget`.
+
+Your device will be discovered as "Nerves Gadget (nerves)". There is a domain name in parenthesis.
 
 ### `:mdns_domain`
 

--- a/lib/nerves_init_gadget/network_manager.ex
+++ b/lib/nerves_init_gadget/network_manager.ex
@@ -131,12 +131,76 @@ defmodule Nerves.InitGadget.NetworkManager do
   defp init_mdns(state, %{mdns_domain: nil}), do: state
 
   defp init_mdns(state, opts) do
-    Mdns.Server.add_service(%Mdns.Server.Service{
-      domain: resolve_mdns_name(opts.mdns_domain),
-      data: :ip,
-      ttl: 120,
-      type: :a
-    })
+    [
+      # resolve ip for domain
+      %Mdns.Server.Service{
+        domain: resolve_mdns_name(opts.mdns_domain),
+        data: :ip,
+        ttl: opts.mdns_ttl,
+        type: :a
+      },
+
+      # ssh service
+      %Mdns.Server.Service{
+        domain: "_services._dns-sd._udp.local",
+        data: "_ssh._tcp.local",
+        ttl: opts.mdns_ttl,
+        type: :ptr
+      },
+      %Mdns.Server.Service{
+        domain: "_ssh._tcp.local",
+        data: "#{mdns_discovery_name(opts)}._ssh._tcp.local",
+        ttl: opts.mdns_ttl,
+        type: :ptr
+      },
+      %Mdns.Server.Service{
+        domain: "#{mdns_discovery_name(opts)}._ssh._tcp.local",
+        data:
+          {0, 0, opts.ssh_console_port,
+           opts.mdns_domain
+           |> resolve_mdns_name()
+           |> :erlang.binary_to_list()},
+        ttl: opts.mdns_ttl,
+        type: :srv
+      },
+      %Mdns.Server.Service{
+        domain: "#{mdns_discovery_name(opts)}._ssh._tcp.local",
+        data: [],
+        ttl: opts.mdns_ttl,
+        type: :txt
+      },
+
+      # sftp service
+      %Mdns.Server.Service{
+        domain: "_services._dns-sd._udp.local",
+        data: "_sftp-ssh._tcp.local",
+        ttl: opts.mdns_ttl,
+        type: :ptr
+      },
+      %Mdns.Server.Service{
+        domain: "_sftp-ssh._tcp.local",
+        data: "#{mdns_discovery_name(opts)}._sftp-ssh._tcp.local",
+        ttl: opts.mdns_ttl,
+        type: :ptr
+      },
+      %Mdns.Server.Service{
+        domain: "#{mdns_discovery_name(opts)}._sftp-ssh._tcp.local",
+        data:
+          {0, 0, opts.ssh_console_port,
+           opts.mdns_domain
+           |> resolve_mdns_name()
+           |> :erlang.binary_to_list()},
+        ttl: opts.mdns_ttl,
+        type: :srv
+      },
+      %Mdns.Server.Service{
+        domain: "#{mdns_discovery_name(opts)}._sftp-ssh._tcp.local",
+        data: [],
+        ttl: opts.mdns_ttl,
+        type: :txt
+      }
+    ]
+    |> Enum.each(&Mdns.Server.add_service/1)
 
     state
   end
@@ -150,6 +214,12 @@ defmodule Nerves.InitGadget.NetworkManager do
   end
 
   defp resolve_mdns_name(mdns_name), do: mdns_name
+
+  defp mdns_discovery_name(opts) do
+    "#{opts.mdns_name} (#{resolve_mdns_name(opts.mdns_domain)})"
+    |> String.replace(".local", "")
+    |> String.replace(".", "_")
+  end
 
   defp to_atom(value) when is_atom(value), do: value
   defp to_atom(value) when is_binary(value), do: String.to_atom(value)

--- a/lib/nerves_init_gadget/options.ex
+++ b/lib/nerves_init_gadget/options.ex
@@ -5,7 +5,9 @@ defmodule Nerves.InitGadget.Options do
 
   defstruct ifname: "usb0",
             address_method: :dhcpd,
+            mdns_name: "Nerves Gadget",
             mdns_domain: "nerves.local",
+            mdns_ttl: 120,
             node_name: nil,
             node_host: :mdns_domain,
             ssh_console_port: 22


### PR DESCRIPTION
This PR will make device discoverable.
Checked with Avahi Discovery, Avahi SSH Server Browse and Mdns.Client.

Fixes: #61

PS. Empty `:txt` record is necessary for some reason.